### PR TITLE
Add multi-plan DAG merge

### DIFF
--- a/tests/plan-parser.test.ts
+++ b/tests/plan-parser.test.ts
@@ -24,4 +24,24 @@ describe('PlanParser', () => {
     expect(dag.getAllNodes().length).toBe(2);
     expect((dag as any).edges.get('a')).toContain('b');
   });
+
+  it('merges multiple plans into a single DAG', () => {
+    const plan1 = `tool: search\nSummarize results`;
+    const plan2 = `tool: calc\nAnswer`;
+
+    const dag = PlanParser.parseMultiple(
+      [plan1, plan2],
+      {
+        search: () => ({ result: 's' }),
+        calc: () => ({ result: 1 })
+      }
+    );
+
+    // Should contain four nodes with prefixed ids
+    expect(dag.getAllNodes().length).toBe(4);
+
+    // Ensure plans are connected sequentially
+    const edges = (dag as any).edges;
+    expect(edges.get('p1_step_2')).toContain('p2_step_1');
+  });
 });


### PR DESCRIPTION
## Summary
- extend PlanParser to merge multiple plans into a single DAG
- add unit test for merging plans

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865e533487c832b9fb5b09effcf6b79