### PR TITLE
Add audit hooks documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ const result = await dag.execute({ topic: "AI trends" });
 ### Running Tests
 
 ```bash
-# Install dependencies
+# Install dependencies (required once before tests)
 npm install
 
 # Build TypeScript

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ const result = await manager.execute({
 - **📊 Resource Constraints**: Schedule with token budgets, rate limits and latency models
 - **🗺️ Plan Parsing**: Convert natural-language or structured plans into DAGs
 - **📈 Critical Path Analysis**: Identify latency bottlenecks for optimization
+- **📝 Plan Auditing**: Review or modify plans before they run
+- **📑 Audit Trails & Hooks**: Capture node execution output with customizable hooks
 
 ## Architecture
 
@@ -135,6 +137,28 @@ const result = await manager.orchestrateConversation(
     "Customer complaint about billing",
     ["analyzer", "researcher", "responder"]
 );
+```
+
+### Plan Auditing and Audit Hooks
+
+```typescript
+import { Agent, Scheduler, PlanAuditHook } from 'tygent';
+
+const agent = new Agent('auditing');
+const hook: PlanAuditHook = (plan) => {
+  if (plan.includes('forbidden')) return false;
+  return plan;
+};
+const dag = await agent.planToDag('compile report', hook);
+
+const scheduler = new Scheduler(dag, {
+  auditDir: './audit_logs',
+  hooks: {
+    beforeNodeExecute: (node) => console.log('start', node.name),
+    afterNodeExecute: (node) => console.log('finish', node.name)
+  }
+});
+await scheduler.execute();
 ```
 
 ### Integration with Popular Frameworks
@@ -297,6 +321,11 @@ const dag = PlanParser.parse(plan, { search: searchTool });
 - **LLMNode**: Language model interactions
 - **APINode**: HTTP/REST API calls
 - **ConditionalNode**: Branching logic
+
+### Audit Utilities
+
+- **PlanAuditHook**: Inspect or alter generated plans before they become DAGs
+- **Scheduler Hooks**: `beforeNodeExecute` and `afterNodeExecute` callbacks for each node
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export { Node, LLMNode, ToolNode } from './nodes';
 export { Scheduler } from './scheduler';
 export { accelerate } from './accelerate';
 export { PlanParser } from './plan';
+export { Agent, PlanAuditHook } from './agent';

--- a/tests/agent-audit.test.ts
+++ b/tests/agent-audit.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from '@jest/globals';
+import { Agent, PlanAuditHook, DAG, ToolNode } from '../src';
+import { Scheduler } from '../src/scheduler';
+import fs from 'fs';
+import path from 'path';
+
+describe('Plan auditing', () => {
+  it('allows audit hook to modify plan', async () => {
+    const agent = new Agent('audit-test');
+    const hook: PlanAuditHook = (plan) => plan.replace('Analyze', 'Review');
+    const dag = await agent.planToDag('sample task', hook);
+    expect(dag).toBeInstanceOf(DAG);
+  });
+
+  it('throws when audit hook rejects plan', async () => {
+    const agent = new Agent('audit-test');
+    const hook: PlanAuditHook = () => false;
+    await expect(agent.planToDag('sample task', hook)).rejects.toThrow(/audit/);
+  });
+});
+
+describe('Scheduler audit trail and hooks', () => {
+  it('writes audit file and can stop execution', async () => {
+    const dag = new DAG('audit');
+    const a = new ToolNode('a', () => ({ val: 1 }));
+    const b = new ToolNode('b', () => ({ val: 2 }));
+    b.setDependencies(['a']);
+    dag.addNode(a);
+    dag.addNode(b);
+    dag.addEdge('a', 'b');
+
+    const dir = path.join(__dirname, 'audit_tmp');
+    if (fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true });
+    }
+
+    const scheduler = new Scheduler(dag, {
+      auditDir: dir,
+      hooks: {
+        beforeNodeExecute: (node) => {
+          if (node.name === 'b') return false;
+        }
+      }
+    });
+
+    const result = await scheduler.execute();
+    expect(result['a']).toBeDefined();
+    expect(result['b']).toBeUndefined();
+    const fileA = path.join(dir, 'a.json');
+    const fileB = path.join(dir, 'b.json');
+    expect(fs.existsSync(fileA)).toBe(true);
+    expect(fs.existsSync(fileB)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- document plan auditing and scheduler hooks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d68e53888832bb82a51c6927e0574